### PR TITLE
chore(.github): add gh token to spin/setup to avoid anon rate limit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,6 +83,7 @@ jobs:
         uses: fermyon/actions/spin/setup@v1
         with:
           plugins: js2wasm
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build fermyon-cloud-gpu
         shell: bash


### PR DESCRIPTION
Adds a GH token to the spin/setup action to make authenticated GH api requests, thus avoiding the lower rate limits when unauthenticated, as seen recently in https://github.com/fermyon/spin-cloud-gpu/actions/runs/10769055253