### PR TITLE
chore(.github): bump ubuntu images to 22.04

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         config:
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-22.04",
               arch: "amd64",
               extension: "",
               buildArgs: "",
@@ -30,7 +30,7 @@ jobs:
               targetDir: "target/release",
             }
           - {
-            os: "ubuntu-20.04",
+            os: "ubuntu-22.04",
             arch: "aarch64",
             extension: "",
             buildArgs: "--target aarch64-unknown-linux-gnu",


### PR DESCRIPTION
Bumps the Ubuntu images to 22.04 per the [deprecation of 20.04](https://github.com/actions/runner-images/issues/11101).